### PR TITLE
Changed merge to create

### DIFF
--- a/firestore/main/index.js
+++ b/firestore/main/index.js
@@ -291,7 +291,7 @@ function updateCreateIfMissing(db) {
 
   var setWithOptions = cityRef.set({
     capital: true
-  }, { merge: true });
+  }, { create: true });
   // [END update_create_if_missing]
 
   return setWithOptions.then(res => {


### PR DESCRIPTION
update_create_if_missing was using "merge" instead of "create" to try and create a document if it didnt exist